### PR TITLE
Deploy app into device using node-firefoxos-cli (remastered to use promises).

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ var jshint = require(buildModules + 'gulp-jshint');
 var yargs = require(buildModules + 'yargs')
 var zip = require(buildModules + 'gulp-zip');
 var clean = require(buildModules + 'gulp-clean');
+var fxoscli = require(buildModules + 'node-firefoxos-cli');
 
 const APP_ROOT = './app/';
 const DIST_ROOT = './dist/';
@@ -92,6 +93,19 @@ gulp.task('zip', function () {
 		])
 		.pipe(zip('app.zip'))
 		.pipe(gulp.dest(DIST_ROOT));
+});
+
+/**
+* Install and launch the app in the device.
+* Device must be setup in developer mode.
+*/
+gulp.task('deploy', ['zip'], function() {
+	var pkg = require('./package.json');
+	var id = pkg.name;
+	var install = fxoscli.installPackagedApp;
+	var launch = fxoscli.launchApp.bind(null, id);
+
+	return install(id, './dist/app.zip').then(launch);
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"gulp-jshint": "^1.9.0",
 		"gulp-zip": "^2.0.2",
 		"jshint": "^2.5.10",
+		"node-firefoxos-cli": "^0.1.1",
 		"yargs": "^1.3.3"
 	}
 }


### PR DESCRIPTION
This will add a new task 'deploy' that will install the app in the phone and launch it.

Uses https://www.npmjs.com/package/node-firefoxos-cli that is a bit old but so far is working.
I noticed a weird behavior, cause of the promise nature of that library, on gulp the task finish but the process doesnt when executing:
`gulp deploy`

Fix #7
