### PR TITLE
Move lint to end of build sequence.

### DIFF
--- a/app_files/gulpfile.js
+++ b/app_files/gulpfile.js
@@ -93,7 +93,7 @@ gulp.task('travis', ['lint', 'loader-polyfill', 'to5']);
  * Build the app.
  */
 gulp.task('build', function(cb) {
-	runSequence(['lint', 'clobber'], ['loader-polyfill', 'copy-app'], 'to5', cb);
+	runSequence(['clobber'], ['loader-polyfill', 'copy-app'], ['to5', 'lint'], cb);
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fxos-build",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"description": "FxOS build scripts and continuous integration support.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This moves the linter to the end of the build step. I want to do this for a few reasons:

1 - Makes it so the app still builds if the linter fails. I think this is useful when rapidly iterating or debugging something. Right now the build dies if the linter fails.
2 - Cleans up output, the linter errors are easier to see if they are moved to the end of the output.

@mikehenrty R?
